### PR TITLE
fixed bug in uploading images

### DIFF
--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -59,7 +59,13 @@ app.get("/image/:id", (req, res) => {
             return;
         }
 
-        res.set('Content-Type', 'image/jpeg');
+        // Set Content-Type based on the file extension from the key
+        const contentType = key.toLowerCase().endsWith('.png') ? 'image/png'
+            : key.toLowerCase().endsWith('.gif') ? 'image/gif'
+                : key.toLowerCase().endsWith('.webp') ? 'image/webp'
+                    : key.toLowerCase().endsWith('.svg') ? 'image/svg+xml'
+                        : 'image/jpeg'; // Default to jpeg for jpg/jpeg/unknown
+        res.set('Content-Type', contentType);
         res.set('Content-Length', data.ContentLength);
         res.send(data);
     })

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -50,13 +50,17 @@ const App = () => {
       const response = await axios.post(`${SERVER_URL}/upload`, formData, {
         headers: {
           // Allow common image file types
-          'Content-Type': 'multipart/form-data'
+          //'Content-Type': 'multipart/form-data'
         },
         timeout: 30000,
       });
 
       if (response.status === 200) {
+        // Set upload success and clear after 3 seconds
         setUploadSuccess(true);
+        setTimeout(() => {
+          setUploadSuccess(false);
+        }, 3000);
         setFile(null);
       }
     } catch (error: unknown) {
@@ -95,6 +99,7 @@ const App = () => {
               </div>
               <input
                 type="file"
+                accept="image/*"
                 className="hidden"
                 onChange={handleFileChange}
               />


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix image upload bug by setting dynamic content types and improving frontend upload handling.
> 
>   - **Backend**:
>     - In `server.ts`, set `Content-Type` dynamically based on file extension for image retrieval, supporting `.png`, `.gif`, `.webp`, `.svg`, and defaulting to `.jpeg`.
>   - **Frontend**:
>     - In `App.tsx`, removed hardcoded `'Content-Type'` header in Axios post request for file upload.
>     - Added `accept="image/*"` attribute to file input to restrict file selection to images.
>     - Implemented a 3-second timeout to clear upload success message after a successful upload.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=fractal-bootcamp%2Ffaisal-file-upload&utm_source=github&utm_medium=referral)<sup> for a68197d8bcfc404e492460ef3ac6cf4ebe8124f8. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->